### PR TITLE
Fix canonical tags on alternate pages

### DIFF
--- a/app/gmb-service-payments/metadata.js
+++ b/app/gmb-service-payments/metadata.js
@@ -1,0 +1,45 @@
+// app/gmb-service-payments/metadata.js
+
+export const metadata = {
+  title: "Subscribe to GBP Management Service | Lumora Ventures",
+  description:
+    "Subscribe to our professional Google Business Profile management service for $150/month. Boost your local SEO, attract more customers, and grow your business.",
+  keywords: [
+    "Google Business Profile Service",
+    "GBP Management Subscription",
+    "Local SEO Service",
+    "Google My Business Management",
+    "Business Profile Optimization",
+    "Lumora Ventures",
+  ],
+  alternates: {
+    canonical: "https://www.lumoraventures.com/gmb-service-payments",
+  },
+  openGraph: {
+    title: "Subscribe to GBP Management Service | Lumora Ventures",
+    description:
+      "Professional Google Business Profile management for $150/month. Boost your local visibility and attract more customers.",
+    url: "https://www.lumoraventures.com/gmb-service-payments",
+    siteName: "Lumora Ventures",
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Subscribe to GBP Management Service | Lumora Ventures",
+    description:
+      "Professional Google Business Profile management for $150/month. Boost your local visibility.",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    nocache: false,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+};

--- a/app/google-my-business/metadata.js
+++ b/app/google-my-business/metadata.js
@@ -11,6 +11,9 @@ export const metadata = {
     "Business Listing",
     "Google Maps",
     "Local Marketing",
+    "Google My Business",
+    "GBP Management",
+    "Local Business Optimization",
   ],
   alternates: {
     canonical: "https://www.lumoraventures.com/google-my-business",
@@ -39,4 +42,17 @@ export const metadata = {
       "Expert Google Business Profile management to improve your local visibility and attract more customers",
     images: ["https://www.lumoraventures.com/images/gmb-twitter-image.jpg"],
   },
+  robots: {
+    index: true,
+    follow: true,
+    nocache: false,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+  category: "business",
 };

--- a/app/privacy-policy/metadata.js
+++ b/app/privacy-policy/metadata.js
@@ -1,0 +1,46 @@
+// app/privacy-policy/metadata.js
+
+export const metadata = {
+  title: "Privacy Policy | Lumora Ventures",
+  description:
+    "Read Lumora Ventures' Privacy Policy to understand how we collect, use, and protect your personal information when you use our services.",
+  keywords: [
+    "Privacy Policy",
+    "Data Protection",
+    "Personal Information",
+    "GDPR",
+    "Privacy Rights",
+    "Data Privacy",
+    "Lumora Ventures",
+  ],
+  alternates: {
+    canonical: "https://www.lumoraventures.com/privacy-policy",
+  },
+  openGraph: {
+    title: "Privacy Policy | Lumora Ventures",
+    description:
+      "Learn how Lumora Ventures collects, uses, and protects your personal information in compliance with privacy regulations.",
+    url: "https://www.lumoraventures.com/privacy-policy",
+    siteName: "Lumora Ventures",
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Privacy Policy | Lumora Ventures",
+    description:
+      "Learn how Lumora Ventures collects, uses, and protects your personal information.",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    nocache: false,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+};

--- a/app/terms-of-service/metadata.js
+++ b/app/terms-of-service/metadata.js
@@ -1,0 +1,45 @@
+// app/terms-of-service/metadata.js
+
+export const metadata = {
+  title: "Terms of Service | Lumora Ventures",
+  description:
+    "Read Lumora Ventures' Terms of Service to understand the legal terms and conditions that govern your use of our services and website.",
+  keywords: [
+    "Terms of Service",
+    "Terms and Conditions",
+    "Legal Terms",
+    "User Agreement",
+    "Service Agreement",
+    "Lumora Ventures",
+  ],
+  alternates: {
+    canonical: "https://www.lumoraventures.com/terms-of-service",
+  },
+  openGraph: {
+    title: "Terms of Service | Lumora Ventures",
+    description:
+      "Review the legal terms and conditions that govern your use of Lumora Ventures' services.",
+    url: "https://www.lumoraventures.com/terms-of-service",
+    siteName: "Lumora Ventures",
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Terms of Service | Lumora Ventures",
+    description:
+      "Review the legal terms and conditions that govern your use of Lumora Ventures' services.",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    nocache: false,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+};


### PR DESCRIPTION
- Add metadata.js with canonical tags for privacy-policy page
- Add metadata.js with canonical tags for terms-of-service page
- Add metadata.js with canonical tags for gmb-service-payments page
- Enhance google-my-business metadata with additional keywords and robot directives for better indexing

This resolves the "Alternate page with proper canonical tag" issue reported in Google Search Console for these pages.