### PR TITLE
Add Facebook domain verification to metadata

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -69,6 +69,9 @@ export const metadata = {
   },
   verification: {
     google: "PUM4vN_Owfm40PwBN31rUydM45YQAm5i7VONVly6w0M",
+    other: {
+      "facebook-domain-verification": ["haw9zmc996l7up42l8cg2h651q27iv"],
+    },
   },
   alternates: {
     canonical: "https://www.lumoraventures.com",


### PR DESCRIPTION
## Summary
Added Facebook domain verification to the application metadata configuration to enable Facebook's domain ownership verification process.

## Changes
- Added `other` verification object to the metadata configuration in `app/layout.js`
- Included Facebook domain verification token: `haw9zmc996l7up42l8cg2h651q27iv`

## Details
This change allows Facebook to verify ownership of the domain by checking the metadata. The verification token is added alongside the existing Google verification configuration, following Next.js metadata API conventions for multiple verification providers.

https://claude.ai/code/session_01VmBrCHH1HWHWC5QZbzwwGL